### PR TITLE
Opting out of strict loading on a per-record base

### DIFF
--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -142,5 +142,11 @@ module ActiveModel
       data.freeze
       assert_nothing_raised { data.freeze }
     end
+
+    test "unknown type error is raised" do
+      assert_raise(ArgumentError) do
+        ModelForAttributesTest.attribute :foo, :unknown
+      end
+    end
   end
 end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Allow to opt-out of `strict_loading` mode on a per-record base.
+
+    This is useful when strict loading is enabled application wide or on a
+    model level.
+
+    ```ruby
+    class User < ApplicationRecord
+      has_many :articles, strict_loading: true
+    end
+
+    user = User.first
+    user.articles
+    # => ActiveRecord::StrictLoadingViolationError
+
+    user = User.first
+    user.stict_loading!(false)
+    user.articles
+    # => #<ActiveRecord::Associations::CollectionProxy>
+    ```
+
+    *Ayrton De Craene*
+
 *   Add `FinderMethods#sole` and `#find_sole_by` to find and assert the
     presence of exactly one record.
 

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -98,7 +98,7 @@ module ActiveRecord
       end
 
       def call
-        return [] if records.empty? || associations.nil?
+        return [] if associations.nil? || records.length == 0
 
         build_preloaders
       end

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -12,9 +12,6 @@ module ActiveRecord
     end
 
     module ClassMethods
-      ##
-      # :call-seq: attribute(name, cast_type = nil, **options)
-      #
       # Defines an attribute with a type on this model. It will override the
       # type of existing attributes if needed. This allows control over how
       # values are converted to and from SQL when assigned to a model. It also
@@ -208,7 +205,7 @@ module ActiveRecord
       # tracking is performed. The methods +changed?+ and +changed_in_place?+
       # will be called from ActiveModel::Dirty. See the documentation for those
       # methods in ActiveModel::Type::Value for more details.
-      def attribute(name, cast_type = nil, default: NO_DEFAULT_PROVIDED, **options, &block)
+      def attribute(name, cast_type = nil, default: NO_DEFAULT_PROVIDED, **options)
         name = name.to_s
         reload_schema_from_cache
 
@@ -218,14 +215,14 @@ module ActiveRecord
         when nil
           if (prev_cast_type, prev_default = attributes_to_define_after_schema_loads[name])
             default = prev_default if default == NO_DEFAULT_PROVIDED
-
-            cast_type = if block_given?
-              -> subtype { yield Proc === prev_cast_type ? prev_cast_type[subtype] : prev_cast_type }
-            else
-              prev_cast_type
-            end
           else
-            cast_type = block || -> subtype { subtype }
+            prev_cast_type = -> subtype { subtype }
+          end
+
+          cast_type = if block_given?
+            -> subtype { yield Proc === prev_cast_type ? prev_cast_type[subtype] : prev_cast_type }
+          else
+            prev_cast_type
           end
         end
 

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -214,8 +214,7 @@ module ActiveRecord
 
         case cast_type
         when Symbol
-          type = cast_type
-          cast_type = -> _ { Type.lookup(type, **options, adapter: Type.adapter_name_from(self)) }
+          cast_type = Type.lookup(cast_type, **options, adapter: Type.adapter_name_from(self))
         when nil
           if (prev_cast_type, prev_default = attributes_to_define_after_schema_loads[name])
             default = prev_default if default == NO_DEFAULT_PROVIDED

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -654,8 +654,8 @@ module ActiveRecord
     #   user.strict_loading!
     #   user.comments.to_a
     #   => ActiveRecord::StrictLoadingViolationError
-    def strict_loading!
-      @strict_loading = true
+    def strict_loading!(value = true)
+      @strict_loading = value
     end
 
     # Marks this record as read only.

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -7,7 +7,7 @@ class PostgresqlTime < ActiveRecord::Base
   # Declare attributes to get rid from deprecation warnings on ActiveRecord 6.1
   attribute :time_interval,        :string
   attribute :scaled_time_interval, :interval
-end
+end if current_adapter?(:PostgreSQLAdapter)
 
 class PostgresqlOid < ActiveRecord::Base
 end

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -16,7 +16,7 @@ class PostgresqlPointTest < ActiveRecord::PostgreSQLTestCase
     attribute :legacy_x, :legacy_point
     attribute :legacy_y, :legacy_point
     attribute :legacy_z, :legacy_point
-  end
+  end if current_adapter?(:PostgreSQLAdapter)
 
   def setup
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/postgresql/interval_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/interval_test.rb
@@ -12,7 +12,7 @@ class PostgresqlIntervalTest < ActiveRecord::PostgreSQLTestCase
     attribute :default_term, :interval
     attribute :all_terms,    :interval, array: true
     attribute :legacy_term,  :string
-  end
+  end if current_adapter?(:PostgreSQLAdapter)
 
   class DeprecatedIntervalDataType < ActiveRecord::Base; end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -379,6 +379,25 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_predicate post.comments, :loaded?
     assert_equal [comments(:greetings)], post.comments
   end
+
+  def test_preload_makes_correct_number_of_queries_on_array
+    post = posts(:welcome)
+
+    assert_queries(1) do
+      preloader = ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments)
+      preloader.call
+    end
+  end
+
+  def test_preload_makes_correct_number_of_queries_on_relation
+    post = posts(:welcome)
+    relation = Post.where(id: post.id)
+
+    assert_queries(2) do
+      preloader = ActiveRecord::Associations::Preloader.new(records: relation, associations: :comments)
+      preloader.call
+    end
+  end
 end
 
 class GeneratedMethodsTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -348,6 +348,12 @@ module ActiveRecord
       assert_equal "foo", klass.new(no_type: "foo").no_type
     end
 
+    test "unknown type error is raised" do
+      assert_raise(ArgumentError) do
+        OverloadedType.attribute :foo, :unknown
+      end
+    end
+
     test "immutable_strings_by_default changes schema inference for string columns" do
       with_immutable_strings do
         OverloadedType.reset_column_information

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -597,15 +597,8 @@ end
 
 class InheritanceAttributeMappingTest < ActiveRecord::TestCase
   setup do
-    @old_registry = ActiveRecord::Type.registry
-    ActiveRecord::Type.registry = ActiveRecord::Type.registry.dup
-    ActiveRecord::Type.register :omg_sti, InheritanceAttributeMappingTest::OmgStiType
     Company.delete_all
     Sponsor.delete_all
-  end
-
-  teardown do
-    ActiveRecord::Type.registry = @old_registry
   end
 
   class OmgStiType < ActiveRecord::Type::String
@@ -623,6 +616,8 @@ class InheritanceAttributeMappingTest < ActiveRecord::TestCase
       end
     end
   end
+
+  ActiveRecord::Type.register :omg_sti, OmgStiType
 
   class Company < ActiveRecord::Base
     self.table_name = "companies"

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -24,6 +24,13 @@ class StrictLoadingTest < ActiveRecord::TestCase
     assert_raises ActiveRecord::StrictLoadingViolationError do
       developer.audit_logs.to_a
     end
+
+    developer.strict_loading!(false)
+    assert_not_predicate developer, :strict_loading?
+
+    assert_nothing_raised do
+      developer.audit_logs.to_a
+    end
   end
 
   def test_strict_loading
@@ -147,6 +154,10 @@ class StrictLoadingTest < ActiveRecord::TestCase
     dev = Developer.eager_load(:strict_loading_audit_logs).first
 
     assert dev.strict_loading_audit_logs.all?(&:strict_loading?), "Expected all audit logs to be strict_loading"
+
+    dev = Developer.eager_load(:strict_loading_audit_logs).strict_loading(false).first
+
+    assert dev.audit_logs.none?(&:strict_loading?), "Expected no audit logs to be strict_loading"
   end
 
   def test_eager_load_audit_logs_are_strict_loading_because_parent_is_strict_loading
@@ -160,6 +171,11 @@ class StrictLoadingTest < ActiveRecord::TestCase
 
     assert_predicate dev, :strict_loading?
     assert dev.audit_logs.all?(&:strict_loading?), "Expected all audit logs to be strict_loading"
+
+    dev = Developer.eager_load(:audit_logs).strict_loading(false).first
+
+    assert_not_predicate dev, :strict_loading?
+    assert dev.audit_logs.none?(&:strict_loading?), "Expected no audit logs to be strict_loading"
   end
 
   def test_eager_load_audit_logs_are_strict_loading_because_it_is_strict_loading_by_default

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -702,7 +702,7 @@ development:
   adapter: async
 
 test:
-  adapter: async
+  adapter: test
 
 production:
   adapter: redis

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -97,7 +97,7 @@ module Rails
         class_option :edge,                type: :boolean, default: false,
                                            desc: "Set up the #{name} with Gemfile pointing to Rails repository"
 
-        class_option :master,              type: :boolean, default: false,
+        class_option :main,                type: :boolean, default: false, aliases: "--master",
                                            desc: "Set up the #{name} with Gemfile pointing to Rails repository main branch"
 
         class_option :rc,                  type: :string, default: nil,
@@ -279,7 +279,7 @@ module Rails
           [
             GemfileEntry.github("rails", "rails/rails", "main")
           ]
-        elsif options.master?
+        elsif options.main?
           [
             GemfileEntry.github("rails", "rails/rails", "main")
           ]

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -46,7 +46,7 @@ end
 group :development do
 <%- unless options.api? || options.skip_dev_gems? -%>
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  <%- if options.dev? || options.edge? || options.master? -%>
+  <%- if options.dev? || options.edge? || options.main? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>
   gem 'web-console', '>= 4.1.0'

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  <%= '# ' if options.dev? || options.edge? || options.master? -%>spec.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
+  <%= '# ' if options.dev? || options.edge? || options.main? -%>spec.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 <% if options[:skip_gemspec] -%>
-<%= '# ' if options.dev? || options.edge? || options.master? -%>gem 'rails', '<%= Array(rails_version_specifier).join("', '") %>'
+<%= '# ' if options.dev? || options.edge? || options.main? -%>gem 'rails', '<%= Array(rails_version_specifier).join("', '") %>'
 <% else -%>
 # Specify your gem's dependencies in <%= name %>.gemspec.
 gemspec

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -809,8 +809,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_web_console_with_master_option
-    run_generator [destination_root, "--master"]
+  def test_web_console_with_main_option
+    run_generator [destination_root, "--main"]
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
@@ -862,6 +862,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_master_option
     generator([destination_root], master: true, skip_webpack_install: true)
+    run_generator_instance
+
+    assert_equal 1, @bundle_commands.count("install")
+    assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
+  end
+
+  def test_main_option
+    generator([destination_root], main: true, skip_webpack_install: true)
     run_generator_instance
 
     assert_equal 1, @bundle_commands.count("install")

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -862,7 +862,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_master_option
     run_generator [destination_root, "--master"]
-    assert_equal 1, @bundle_commands.count("install")
     assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -861,9 +861,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_master_option
-    generator([destination_root], master: true, skip_webpack_install: true)
-    run_generator_instance
-
+    run_generator [destination_root, "--master"]
     assert_equal 1, @bundle_commands.count("install")
     assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
   end


### PR DESCRIPTION
### Summary

Provide a way to opt out of strict loader on a per-record base. This is useful when strict loading is enabled application wide or on model level.

This was initially reported in <GH_ISSUE_HERE>.

### Other Information

```
~/Developer/ayrton/rails/activerecord [activerecord-strict-loading-optout]
$ ARCONN=postgresql bundle exec ruby -Itest test/cases/strict_loading_test.rb
Using postgresql
Run options: --seed 29040

# Running:

...................................

Finished in 1.131122s, 30.9427 runs/s, 71.6103 assertions/s.
35 runs, 81 assertions, 0 failures, 0 errors, 0 skips
```
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
